### PR TITLE
Test, clean up archive/CleanFilePath, getStrategy

### DIFF
--- a/archive/clean.go
+++ b/archive/clean.go
@@ -5,13 +5,9 @@ import (
 )
 
 func CleanFileName(fileName string) string {
-	// input path may be with `\` or `/` separator
-	// this normalizes to `/`
-	nativeFileName := filepath.ToSlash(fileName)
-
 	// clean returns the shortest possible path,
 	// resolving `..`, double separators etc.
-	cleanedNative := filepath.Clean(nativeFileName)
+	cleanedNative := filepath.Clean(fileName)
 
 	// clean's output uses the native separator, so
 	// `\` on windows.

--- a/archive/clean_test.go
+++ b/archive/clean_test.go
@@ -1,0 +1,88 @@
+package archive
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// These tests are modified from Go's filepath tests
+
+type PathTest struct {
+	path, result string
+}
+
+var cleantests = []PathTest{
+	// Already clean
+	{"abc", "abc"},
+	{"abc/def", "abc/def"},
+	{"a/b/c", "a/b/c"},
+	{".", "."},
+	{"..", ".."},
+	{"../..", "../.."},
+	{"../../abc", "../../abc"},
+	{"/abc", "/abc"},
+	{"/", "/"},
+
+	// Empty is current dir
+	{"", "."},
+
+	// Remove trailing slash
+	{"abc/", "abc"},
+	{"abc/def/", "abc/def"},
+	{"a/b/c/", "a/b/c"},
+	{"./", "."},
+	{"../", ".."},
+	{"../../", "../.."},
+	{"/abc/", "/abc"},
+
+	// Remove doubled slash
+	{"abc//def//ghi", "abc/def/ghi"},
+	{"//abc", "/abc"},
+	{"///abc", "/abc"},
+	{"//abc//", "/abc"},
+	{"abc//", "abc"},
+
+	// Remove . elements
+	{"abc/./def", "abc/def"},
+	{"/./abc/def", "/abc/def"},
+	{"abc/.", "abc"},
+
+	// Remove .. elements
+	{"abc/def/ghi/../jkl", "abc/def/jkl"},
+	{"abc/def/../ghi/../jkl", "abc/jkl"},
+	{"abc/def/..", "abc"},
+	{"abc/def/../..", "."},
+	{"/abc/def/../..", "/"},
+	{"abc/def/../../..", ".."},
+	{"/abc/def/../../..", "/"},
+	{"abc/def/../../../ghi/jkl/../../../mno", "../../mno"},
+	{"/../abc", "/abc"},
+
+	// Combinations
+	{"abc/./../def", "def"},
+	{"abc//./../def", "def"},
+	{"abc/../../././../def", "../../def"},
+	{`c:`, `c:.`},
+	{`c:\`, `c:/`},
+	{`c:\abc`, `c:/abc`},
+	{`c:abc\..\..\.\.\..\def`, `c:../../def`},
+	{`c:\abc\def\..\..`, `c:/`},
+	{`c:\..\abc`, `c:/abc`},
+	{`c:..\abc`, `c:../abc`},
+	{`\`, `/`},
+	{`/`, `/`},
+	{`\\i\..\c$`, `/c$`},
+	{`\\i\..\i\c$`, `/i/c$`},
+	{`\\i\..\I\c$`, `/I/c$`},
+	{`\\host\share\foo\..\bar`, `//host/share/bar`},
+	{`//host/share/foo/../baz`, `//host/share/baz`},
+	{`\\a\b\..\c`, `//a/b/c`},
+	{`\\a\b`, `//a/b`},
+}
+
+func TestCleanFileName(t *testing.T) {
+	for _, cas := range cleantests {
+		assert.Equal(t, cas.result, CleanFileName(cas.path))
+	}
+}

--- a/archive/probe.go
+++ b/archive/probe.go
@@ -136,17 +136,19 @@ func (ai *ArchiveInfo) GetExtractor(file eos.File, consumer *state.Consumer) (sa
 	return nil, fmt.Errorf("unknown ArchiveStrategy %d", ai.Strategy)
 }
 
+var (
+	archiveStrategyStrings = map[ArchiveStrategy]string{
+		ArchiveStrategyTar:    "tar",
+		ArchiveStrategyTarBz2: "tar.bz2",
+		ArchiveStrategyTarGz:  "tar.gz",
+		ArchiveStrategyZip:    "zip",
+	}
+)
+
 func (as ArchiveStrategy) String() string {
-	switch as {
-	case ArchiveStrategyTar:
-		return "tar"
-	case ArchiveStrategyTarBz2:
-		return "tar.bz2"
-	case ArchiveStrategyTarGz:
-		return "tar.gz"
-	case ArchiveStrategyZip:
-		return "zip"
-	default:
+	str, ok := archiveStrategyStrings[as]
+	if !ok {
 		return "?"
 	}
+	return str
 }

--- a/archive/probe_test.go
+++ b/archive/probe_test.go
@@ -1,0 +1,96 @@
+package archive
+
+import (
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/itchio/wharf/state"
+	"github.com/stretchr/testify/assert"
+)
+
+type StrategyTest struct {
+	fileName string
+	result   ArchiveStrategy
+}
+
+var (
+	strategyTests = []StrategyTest{
+		{"foo_bar.zip", ArchiveStrategyZip},
+		{"foo_bar.tar", ArchiveStrategyTar},
+		{"foo_bar.tar.gz", ArchiveStrategyTarGz},
+		{"foo_bar.tar.bz2", ArchiveStrategyTarBz2},
+		{"foo_bar.7z", ArchiveStrategySevenZip},
+		{"foo_bar.rar", ArchiveStrategySevenZip},
+		{"foo_bar.dmg", ArchiveStrategySevenZip},
+		{"foo_bar.exe", ArchiveStrategySevenZip},
+		{"foo_bar", ArchiveStrategySevenZip},
+	}
+)
+
+func TestGetStrategy(t *testing.T) {
+	consumer := &state.Consumer{}
+	for _, cas := range strategyTests {
+		ff := fakeFile{
+			fileName: cas.fileName,
+			canStat:  true,
+		}
+		strat := getStrategy(ff, consumer)
+		assert.Equal(t, cas.result, strat)
+	}
+}
+
+func TestGetStrategyNoStat(t *testing.T) {
+	// Only one test case here
+	ff := fakeFile{}
+	strat := getStrategy(ff, &state.Consumer{})
+	assert.Equal(t, ArchiveStrategyNone, strat)
+}
+
+type fakeFile struct {
+	fileName string
+	canStat  bool
+}
+
+func (ff fakeFile) Read([]byte) (int, error) {
+	return 0, errors.New("Fake files can't read")
+}
+func (ff fakeFile) Close() error {
+	return errors.New("Fake files can't close")
+}
+func (ff fakeFile) ReadAt([]byte, int64) (int, error) {
+	return 0, errors.New("Fake files can't read")
+}
+func (ff fakeFile) Seek(int64, int) (int64, error) {
+	return 0, errors.New("Fake files can't seek")
+}
+func (ff fakeFile) Stat() (os.FileInfo, error) {
+	if ff.canStat {
+		return fakeFileInfo{name: ff.fileName}, nil
+	}
+	return fakeFileInfo{}, errors.New("This fake file can't Stat()")
+}
+
+type fakeFileInfo struct {
+	name string
+}
+
+func (ffi fakeFileInfo) Name() string {
+	return ffi.name
+}
+func (ffi fakeFileInfo) Size() int64 {
+	return 0
+}
+func (ffi fakeFileInfo) IsDir() bool {
+	return false
+}
+func (ffi fakeFileInfo) ModTime() time.Time {
+	return time.Time{}
+}
+func (ffi fakeFileInfo) Mode() os.FileMode {
+	return 0
+}
+func (ffi fakeFileInfo) Sys() interface{} {
+	return nil
+}


### PR DESCRIPTION
This is a simple changeset removing an excess `filepath.ToSlash` call from `archive.CleanFileName`, also bringing over tests from the stdlib `filepath` package to verify no change happened in that removal.

It also adds tests for archive.getStrategy, and uses a map for archive strategy strings.