### PR TITLE
Updating pushing docs

### DIFF
--- a/docs/pushing.md
+++ b/docs/pushing.md
@@ -51,7 +51,7 @@ The name of a channel has meaning:
 
   * If it contains `win` or `windows`, it'll be tagged as a Windows executable
   * If it contains `linux`, it'll be tagged as a Linux executable
-  * If it contains `osx`, it'll be tagged as a Mac executable
+  * If it contains `mac` or `osx`, it'll be tagged as a Mac executable
   * If it contains `android`, it'll be tagged as an Android application
   * Channel names may contain multiple platforms (for example, a Java game could be pushed
     to `win-linux-mac-stable`)


### PR DESCRIPTION
Experimentally, "mac" also works for getting tagged as a Mac executable. There may be other hidden auto-tag strings, but I'm not sure where that processing happens...