### PR TITLE
Any upload is better than no upload

### DIFF
--- a/endpoints/install/install_plan.go
+++ b/endpoints/install/install_plan.go
@@ -40,7 +40,11 @@ func InstallPlan(rc *butlerd.RequestContext, params butlerd.InstallPlanParams) (
 	if err != nil {
 		return nil, err
 	}
-	baseUploads = narrowRes.Uploads
+
+	if len(narrowRes.Uploads) != 0 {
+		consumer.Statf("No compatible uploads, showing incompatible uploads as well.")
+		baseUploads = narrowRes.Uploads
+	}
 
 	// exclude already-installed and currently-installing uploads
 	var uploadIDs []interface{}


### PR DESCRIPTION
Basically, if all the uploads get filtered, then the user can't download the app, this PR changes the behavior and if there are no valid updates left, then it allows the user to choose any of the uploads. How could this be helpful? In my case, I commonly use itch app for game jams, but if the dev doesn't select the appropriate platform, suddenly his game is not downloadable by itch. 

This PR changes behavior from this:
![image](https://user-images.githubusercontent.com/25201406/187193113-56fc8d7f-7b1c-476e-a217-e1c50c8037ce.png)

To this:
![image](https://user-images.githubusercontent.com/25201406/187193209-fd6eee85-bee7-4a1d-848b-a48ddb046463.png)

However if dev does specify the platform, then no changes are made and user gets shown only the appropriate ones for his OS.
It might be nice to notify the user about the unknown platform in the itch app, I think I can add that later.