### PR TITLE
Add arm64 build option

### DIFF
--- a/release/build.js
+++ b/release/build.js
@@ -50,6 +50,7 @@ const OS_INFOS = {
   darwin: {
     architectures: {
       x86_64: {},
+      arm64: {},
     },
   },
 };
@@ -61,7 +62,7 @@ async function main(args) {
   /**
    * @type {{
    *   os: "windows" | "linux" | "darwin",
-   *   arch: "i686" | "x86_64",
+   *   arch: "i686" | "x86_64" | "arm64",
    *   userSpecifiedOS?: boolean,
    *   userSpecifiedArch?: boolean,
    * }}
@@ -94,7 +95,7 @@ async function main(args) {
             throw new Error(`Unsupported os ${chalk.yellow(v)}`);
           }
         } else if (k === "arch") {
-          if (v === "i686" || v === "x86_64") {
+          if (v === "i686" || v === "x86_64" || v === "arm64") {
             opts.arch = v;
             opts.userSpecifiedArch = true;
           } else {
@@ -249,8 +250,8 @@ async function main(args) {
 }
 
 /**
- * @param {"i686" | "x86_64"} arch
- * @returns {"386" | "amd64"}
+ * @param {"i686" | "x86_64" | "arm64"} arch
+ * @returns {"386" | "amd64" | "arm64"}
  */
 function archToGoArch(arch) {
   switch (arch) {
@@ -258,6 +259,8 @@ function archToGoArch(arch) {
       return "386";
     case "x86_64":
       return "amd64";
+    case "arm64":
+      return "arm64";
     default:
       throw new Error(`unsupported arch: ${chalk.yellow(arch)}`);
   }


### PR DESCRIPTION

This adds an `arm64` build option.

```
❯ node release/build.js --os darwin --arch arm64
Using user-specified OS darwin
Using user-specified arch arm64

―――――――――――――――――――――――
 Showing tool versions
―――――――――――――――――――――――

📜 node --version
v22.11.0
📜 go version
go version go1.23.4 darwin/arm64
📜 date +%s
export CGO_CFLAGS=-mmacosx-version-min=10.10
export CGO_LDFLAGS=-mmacosx-version-min=10.10
Compiling binary
export GOOS=darwin
export GOARCH=arm64
export CGO_ENABLED=1
📜 go build -ldflags "-X github.com/itchio/butler/buildinfo.Version=head -X github.com/itchio/butler/buildinfo.BuiltAt=1735830626
 -X github.com/itchio/butler/buildinfo.Commit= -w -s"
# github.com/itchio/sevenzip-go/sz
glue.c:119:29: warning: passing arguments to a function without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]

――――――――――――――
 Packaging...
――――――――――――――

📜 mv butler ./artifacts/darwin-arm64/butler
📜 file ./artifacts/darwin-arm64/butler
./artifacts/darwin-arm64/butler: Mach-O 64-bit executable arm64
📜 ./artifacts/darwin-arm64/butler -V
head, built on Jan  2 2025 @ 08:10:26
📜 ./artifacts/darwin-arm64/butler fetch-7z-libs
📜 go test -v ./butlerd/integrate --butlerPath='/Users/nicholasduffy/code/butler/artifacts/darwin-arm64/butler'
# github.com/itchio/sevenzip-go/sz

# .... tests here

ok      github.com/itchio/butler/butlerd/integrate      8.896s
```

### Notes

- Of course, I can't test the itch.io executable signing, so commented that out in my testing.
- The build results in this:

```
❯ uname -a
Darwin me.local 23.6.0 Darwin Kernel Version 23.6.0: Fri Nov 15 15:13:15 PST 2024; root:xnu-10063.141.1.702.7~1/RELEASE_ARM64_T6000 arm64

❯ ./artifacts/darwin-arm64/butler -V
head, built on Jan  2 2025 @ 08:13:58
```

### Related issues
- This should resolve https://github.com/itchio/itch/pull/2928