### PR TITLE
Security: Path Traversal in clean command

### DIFF
--- a/cmd/clean/clean.go
+++ b/cmd/clean/clean.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/itchio/butler/comm"
@@ -45,6 +46,19 @@ func Do(planPath string) error {
 
 	for _, entry := range plan.Entries {
 		fullPath := filepath.Join(plan.BasePath, entry)
+
+		// Resolve any path traversal sequences (e.g., "..")
+		fullPath = filepath.Clean(fullPath)
+		basePath := filepath.Clean(plan.BasePath)
+
+		// Ensure the resolved path is within the base path
+		if !strings.HasPrefix(fullPath, basePath) {
+			return errors.Errorf("path traversal attempt detected: %s is not within %s", entry, plan.BasePath)
+		}
+		// Ensure there's a path separator to prevent /basepathABC matching /basepath
+		if len(fullPath) > len(basePath) && fullPath[len(basePath)] != filepath.Separator {
+			return errors.Errorf("path traversal attempt detected: %s is not within %s", entry, plan.BasePath)
+		}
 
 		stat, err := os.Lstat(fullPath)
 		if err != nil {


### PR DESCRIPTION
## Summary

Security: Path Traversal in clean command

## Problem

**Severity**: `High` | **File**: `cmd/clean/clean.go:L47`

The clean command reads a JSON plan with entries and joins them with BasePath without validating for path traversal sequences like '..'. An attacker could craft a malicious plan to delete files outside the intended directory.

## Solution

Validate that the resulting fullPath is within plan.BasePath using filepath.Clean() or by checking the resolved path starts with the base path.

## Changes

- `cmd/clean/clean.go` (modified)